### PR TITLE
Remove unneeded dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,19 +23,6 @@
         </repository>
     </repositories>
 
-    <dependencies>
-        <dependency>
-            <groupId>org</groupId>
-            <artifactId>spigotmc.api</artifactId>
-            <version>1.8.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org</groupId>
-            <artifactId>spigotmc</artifactId>
-            <version>1.8.8</version>
-        </dependency>
-    </dependencies>
-
     <distributionManagement>
         <snapshotRepository>
             <id>nexus</id>


### PR DESCRIPTION
- This can be safely removed as it should be provided by the user in their maven pom.xml file.
- It is also a pain to have to manually update, they are outdated right now.
- I have tested it and it works if you manually remove those dependencies.
